### PR TITLE
implement random acronym filler

### DIFF
--- a/apps/hai/src/app/app.component.ts
+++ b/apps/hai/src/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent implements OnInit {
     appName: 'HAI',
     appTagline: 'Software, cloud, and personal-cloud systems.',
     appDescription:
-      'Hopeful Aspirations Integrators builds software systems, cloud platforms, and personal cloud tooling for people who want durable, owned computing.',
+      'HAI (Heavily Articulated Iguanas) builds software systems, cloud platforms, and personal cloud tooling for people who want durable, owned computing.',
     appUrl: '/hai',
   };
 

--- a/apps/hai/src/app/components/landing/landing.component.html
+++ b/apps/hai/src/app/components/landing/landing.component.html
@@ -25,9 +25,9 @@
         Software, cloud, and personal-cloud systems for digital homesteading.
       </h1>
       <p class="lede">
-        HAI helps people and organizations build durable software, calmer cloud
-        architecture, and pre-configured personal computing systems they can
-        actually own.
+        <hai-expansion></hai-expansion> helps people and organizations build
+        durable software, calmer cloud architecture, and pre-configured personal
+        computing systems they can actually own.
       </p>
 
       <div class="hero-actions">
@@ -166,6 +166,29 @@
     </div>
   </section>
 
+  <section class="acronym-generator-panel" data-theme-surface="feature">
+    <div
+      class="section-copy"
+      style="text-align: center; max-width: 800px; margin: 0 auto"
+    >
+      <p class="eyebrow">Marketing Strategy</p>
+      <h2>What does HAI actually stand for?</h2>
+      <p>
+        The meaning of HAI is fluid, dynamic, and essentially meaningless. We
+        change it constantly to keep our SEO team on their toes and our brand
+        identity comfortably vague.
+      </p>
+
+      <div class="generator-box" data-theme-surface="card">
+        <p>Today, for you, HAI means:</p>
+        <div class="big-acronym">
+          <hai-expansion [showExpansionOnInit]="true"></hai-expansion>
+        </div>
+        <p class="hint">Click the acronym to generate a new brand identity.</p>
+      </div>
+    </div>
+  </section>
+
   <section class="contact-panel" data-theme-surface="hero" id="contact">
     <p class="eyebrow">Work With HAI</p>
     <h2>
@@ -174,8 +197,8 @@
     </h2>
     <div class="hero-actions" style="justify-content: center">
       <a class="cta primary" href="/hai-computer">Go to HAI Computer</a>
-      <a class="cta secondary" href="mailto:hello@hopefulaspirations.com"
-        >hello@hopefulaspirations.com</a
+      <a class="cta secondary" href="mailto:hello@hai.computer"
+        >hello@hai.computer</a
       >
     </div>
   </section>

--- a/apps/hai/src/app/components/landing/landing.component.scss
+++ b/apps/hai/src/app/components/landing/landing.component.scss
@@ -633,3 +633,66 @@ h3 {
     transform: none;
   }
 }
+
+.acronym-generator-panel {
+  margin-top: clamp(2.5rem, 5vw, 4rem);
+  padding: clamp(2rem, 5vw, 4.5rem) clamp(1rem, 3vw, 2.5rem);
+  border-radius: var(--hai-radius-panel);
+  border: var(--hai-border-width) var(--hai-border-style) var(--hai-outline);
+  box-shadow: var(--hai-shadow-panel);
+
+  .generator-box {
+    margin-top: 2.5rem;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    border-radius: var(--hai-radius-panel);
+    border: var(--hai-border-width) var(--hai-border-style)
+      color-mix(in srgb, var(--primary) 15%, transparent);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    background: color-mix(
+      in srgb,
+      var(--surface, var(--background)) 94%,
+      var(--primary) 6%
+    );
+
+    p {
+      margin: 0;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      font-size: 0.85rem;
+      color: color-mix(in srgb, var(--foreground) 50%, transparent);
+    }
+
+    .big-acronym {
+      font-family: var(--font-heading, Georgia, serif);
+      font-size: clamp(2rem, 6vw, 4.5rem);
+      color: var(--primary);
+      text-align: center;
+      transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+
+      &:hover {
+        transform: scale(1.05);
+      }
+
+      ::ng-deep .hai-expansion-shell {
+        gap: 1.5ch;
+      }
+
+      ::ng-deep .hai-expansion-copy {
+        font-size: 0.7em;
+        font-weight: 500;
+      }
+    }
+
+    .hint {
+      font-size: 0.75rem;
+      opacity: 0.6;
+      font-weight: 400;
+      text-transform: none;
+      letter-spacing: normal;
+    }
+  }
+}

--- a/apps/hai/src/app/components/landing/landing.component.ts
+++ b/apps/hai/src/app/components/landing/landing.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Component, PLATFORM_ID, inject } from '@angular/core';
+import { HaiExpansionComponent } from '@optimistic-tanuki/hai-ui';
 import {
   AuroraRibbonComponent,
   PulseRingsComponent,
@@ -19,6 +20,7 @@ interface EcosystemLink {
   standalone: true,
   imports: [
     CommonModule,
+    HaiExpansionComponent,
     AuroraRibbonComponent,
     PulseRingsComponent,
     ShimmerBeamComponent,

--- a/apps/hai/src/app/components/title-bar/title-bar.component.html
+++ b/apps/hai/src/app/components/title-bar/title-bar.component.html
@@ -1,5 +1,5 @@
 <otui-app-bar
-  appTitle="Hopeful Aspirations Integrators"
+  appTitle="HAI"
   [showThemeToggle]="true"
   [useTile]="true"
   menuIcon="☰"

--- a/apps/hai/src/index.html
+++ b/apps/hai/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Hopeful Aspirations Integrators builds software, cloud platforms, and personal cloud systems for digital homesteading."
+      content="HAI (Highly Arbitrary Initialism) builds software, cloud platforms, and personal cloud systems for digital homesteading."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/system-configurator/src/app/app.component.spec.ts
+++ b/apps/system-configurator/src/app/app.component.spec.ts
@@ -32,7 +32,7 @@ describe('AppComponent', () => {
   it('renders the HAI Computer brand shell', () => {
     expect(component.brandName).toBe('HAI Computer');
     expect(fixture.nativeElement.textContent).toContain(
-      'Hopeful Aspirations Integrators Computers'
+      'Hovering Alien Invaders Computers'
     );
   });
 

--- a/apps/system-configurator/src/app/app.component.ts
+++ b/apps/system-configurator/src/app/app.component.ts
@@ -23,7 +23,7 @@ import { SignalMeshComponent } from '@optimistic-tanuki/motion-ui';
 })
 export class AppComponent implements OnInit {
   readonly brandName = 'HAI Computer';
-  readonly fullBrandName = 'Hopeful Aspirations Integrators Computers';
+  readonly fullBrandName = 'Hovering Alien Invaders Computers';
   readonly haiAboutConfig = {
     appId: 'hai-computer',
     appName: 'HAI Computer',

--- a/apps/system-configurator/src/app/pages/landing/landing.component.ts
+++ b/apps/system-configurator/src/app/pages/landing/landing.component.ts
@@ -15,7 +15,7 @@ import { ConfiguratorStateService } from '../../state/configurator-state.service
           <p class="eyebrow">HAI Computer</p>
           <h1>Purpose-built systems for teams that need calm, durable compute.</h1>
           <p class="lede">
-            Hopeful Aspirations Integrators Computers designs integration-ready
+            Hovering Alien Invaders Computers designs integration-ready
             workstations, storage nodes, and deployment platforms with a tighter
             handoff from planning to purchase.
           </p>

--- a/docs/guides/code-and-scaffold-guidelines.md
+++ b/docs/guides/code-and-scaffold-guidelines.md
@@ -1,4 +1,4 @@
-# HOPEFUL ASPIRATIONS — Project Rules for LLMs
+# HAI (Whatever That Means Today) — Project Rules for LLMs
 
 ## Purpose
 

--- a/libs/hai-ui/src/index.ts
+++ b/libs/hai-ui/src/index.ts
@@ -1,4 +1,6 @@
 export * from './lib/hai-about-tag/hai-about-tag.component';
 export * from './lib/hai-about-modal/hai-about-modal.component';
+export * from './lib/hai-expansion/hai-expansion.component';
 export * from './lib/hai-types/hai-app.config';
 export * from './lib/hai-types/hai-app.directory';
+export * from './lib/hai-types/hai-expansions';

--- a/libs/hai-ui/src/lib/hai-about-modal/hai-about-modal.component.html
+++ b/libs/hai-ui/src/lib/hai-about-modal/hai-about-modal.component.html
@@ -15,11 +15,11 @@
         <span>HAI</span>
       </div>
       <div class="about-intro">
-        <p class="eyebrow">Hopeful Aspirations Integrators</p>
+        <p class="eyebrow">{{ currentExpansion }}</p>
         <h3>{{ config.appName }}</h3>
         <p class="tagline">{{ config.appTagline }}</p>
         <p class="savannah-line">
-          Made with Love in Savannah - Hopeful Aspiration Integrators
+          Made with Love in Savannah - {{ currentExpansion }}
         </p>
       </div>
     </header>

--- a/libs/hai-ui/src/lib/hai-about-modal/hai-about-modal.component.ts
+++ b/libs/hai-ui/src/lib/hai-about-modal/hai-about-modal.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { ModalComponent, Tab, TabsComponent } from '@optimistic-tanuki/common-ui';
 import { HaiAboutConfig } from '../hai-types/hai-app.config';
 import { getHaiAppLinks } from '../hai-types/hai-app.directory';
+import { getRandomHaiExpansion } from '../hai-types/hai-expansions';
 
 @Component({
   selector: 'hai-about-modal',
@@ -11,7 +12,7 @@ import { getHaiAppLinks } from '../hai-types/hai-app.directory';
   templateUrl: './hai-about-modal.component.html',
   styleUrl: './hai-about-modal.component.scss',
 })
-export class HaiAboutModalComponent {
+export class HaiAboutModalComponent implements OnInit {
   @Input({ required: true }) config!: HaiAboutConfig;
   @Input() visible = false;
   @Output() close = new EventEmitter<void>();
@@ -23,6 +24,11 @@ export class HaiAboutModalComponent {
   ];
 
   activeTab = 'app';
+  currentExpansion = '';
+
+  ngOnInit() {
+    this.currentExpansion = getRandomHaiExpansion();
+  }
 
   get appLinks() {
     return getHaiAppLinks(this.config?.appId);

--- a/libs/hai-ui/src/lib/hai-about-tag/hai-about-tag.component.spec.ts
+++ b/libs/hai-ui/src/lib/hai-about-tag/hai-about-tag.component.spec.ts
@@ -40,7 +40,7 @@ describe('HaiAboutTagComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain(
-      'Made with Love in Savannah - Hopeful Aspiration Integrators'
+      'Made with Love in Savannah - '
     );
   });
 });

--- a/libs/hai-ui/src/lib/hai-expansion/hai-expansion.component.ts
+++ b/libs/hai-ui/src/lib/hai-expansion/hai-expansion.component.ts
@@ -1,0 +1,67 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnInit, signal } from '@angular/core';
+import { getRandomHaiExpansion } from '../hai-types/hai-expansions';
+
+@Component({
+  selector: 'hai-expansion',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <span class="hai-expansion-shell" (click)="regenerate()">
+      <span class="hai-initials">HAI</span>
+      @if (showExpansion()) {
+        <span class="hai-expansion-copy">
+          <span class="bracket">(</span>{{ currentExpansion() }}<span class="bracket">)</span>
+        </span>
+      }
+    </span>
+  `,
+  styles: [`
+    .hai-expansion-shell {
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5ch;
+      user-select: none;
+      transition: color 0.2s ease;
+    }
+
+    .hai-initials {
+      font-weight: 700;
+      letter-spacing: 0.05em;
+    }
+
+    .hai-expansion-copy {
+      font-style: italic;
+      opacity: 0.8;
+      font-size: 0.9em;
+    }
+
+    .bracket {
+      opacity: 0.5;
+      margin: 0 0.1ch;
+    }
+
+    .hai-expansion-shell:hover .hai-initials {
+      color: var(--primary, #3b82f6);
+    }
+  `]
+})
+export class HaiExpansionComponent implements OnInit {
+  @Input() showExpansionOnInit = true;
+
+  readonly currentExpansion = signal('');
+  readonly showExpansion = signal(false);
+
+  ngOnInit() {
+    this.currentExpansion.set(getRandomHaiExpansion());
+    if (this.showExpansionOnInit) {
+      this.showExpansion.set(true);
+    }
+  }
+
+  regenerate() {
+    this.currentExpansion.set(getRandomHaiExpansion());
+    this.showExpansion.set(true);
+  }
+}

--- a/libs/hai-ui/src/lib/hai-types/hai-expansions.ts
+++ b/libs/hai-ui/src/lib/hai-types/hai-expansions.ts
@@ -1,0 +1,23 @@
+export const HAI_EXPANSIONS = [
+  'Highly Arbitrary Initialism',
+  'Heavily Articulated Iguanas',
+  'Holographic Artichoke Investors',
+  'Haphazard Algorithm Incubator',
+  'Habitually Arguing Idiots',
+  'Half-baked Artificial Intelligence',
+  'Hovering Alien Invaders',
+  'Hypnotic Avocado Illusion',
+  'Heavy Analytical Instruments',
+  'Harmlessly Absurd Interlopers',
+  'Hollow Administrative Ideas',
+  'Heroic Aardvark Innovations',
+  'Historical Anomaly Investigators',
+  'Hidden API Illuminati',
+  'Homesteaders Against Interfaces',
+  'Haunted Architecture Inc.',
+];
+
+export function getRandomHaiExpansion(): string {
+  const randomIndex = Math.floor(Math.random() * HAI_EXPANSIONS.length);
+  return HAI_EXPANSIONS[randomIndex];
+}


### PR DESCRIPTION
This pull request updates the branding and marketing language for HAI across the codebase, shifting from "Hopeful Aspirations Integrators" to a more playful, dynamic, and ambiguous identity with randomly generated expansions of the HAI acronym. It introduces a new interactive component for displaying and regenerating HAI expansions, updates references in UI, documentation, and metadata, and adapts styling to support the new features.

**Branding and Marketing Language Overhaul:**

* Replaced all references to "Hopeful Aspirations Integrators" with dynamic or humorous expansions of "HAI" (e.g., "Heavily Articulated Iguanas", "Highly Arbitrary Initialism", "Hovering Alien Invaders") throughout the app, documentation, and tests. [[1]](diffhunk://#diff-030d3ac614a41ca2c47dbaf1631caa2355090201fd3aa4851624050be7d4eef7L28-R28) [[2]](diffhunk://#diff-9b96fbcd1f498fd079ae9133d9d307f68b5b4a6e1259e39dfe270c2cf6bbb51bL10-R10) [[3]](diffhunk://#diff-f4a290581972ca28261c66e3f7b34372f3bc687ef4bcc9ad5f7d5324c397f50aL26-R26) [[4]](diffhunk://#diff-bfa32c9d168673ecf94b2402e2b211b88a9edcaeccd9be2e59c9808e7ae65b08L35-R35) [[5]](diffhunk://#diff-dc38ef787d31e97f9223de46ea0d22bae020b15f54b567265634483e04407383L18-R18) [[6]](diffhunk://#diff-e61f860f20974ac31b721b3bb7e1bd0cd105edbf940b5fbe4e94e6ad796294f5L2-R2) [[7]](diffhunk://#diff-62241552d3bfb8a40fe98bca5dd2c8bf868700bed22b214e34b427865b732241L1-R1) [[8]](diffhunk://#diff-f9c2f01fb1e87d0408aef17e14ab03a0d1339c4a26e54b8ad68cb0b3c9a43d5eL18-R22) [[9]](diffhunk://#diff-7919eee86515cf2bfcf8380f254624ab5b9feb27fd41aa5dc4ae5bbf73f2c1abL43-R43)

* Updated the contact email to use the new HAI branding (`hello@hai.computer`).

**New Interactive Acronym Expansion Feature:**

* Added a new `HaiExpansionComponent` that displays a random, playful expansion of "HAI" and allows users to generate new expansions interactively. [[1]](diffhunk://#diff-57b961a33ac45419eded36746bd1257de6b81f9dc60adc6076733f396ba6fd03R1-R67) [[2]](diffhunk://#diff-e1a30d0d797f027bf77707fa8330f5c44040a330c60195433505a7a1cb3f9e58R3-R6) [[3]](diffhunk://#diff-5f5218716c2db3ad9aac42d23c4e13fa62b13a2ac9e44de62b0046bc8e3e153bR3) [[4]](diffhunk://#diff-5f5218716c2db3ad9aac42d23c4e13fa62b13a2ac9e44de62b0046bc8e3e153bR23)

* Added a section to the landing page that highlights the dynamic and intentionally ambiguous meaning of HAI, featuring the new acronym generator. [[1]](diffhunk://#diff-378748926fb1d851f67dcaf29518af91b4d36c22a1722920d775b1721aa9184eR169-R191) [[2]](diffhunk://#diff-378748926fb1d851f67dcaf29518af91b4d36c22a1722920d775b1721aa9184eL28-R30)

* Introduced a utility and data source for generating random HAI expansions (`hai-expansions.ts`). [[1]](diffhunk://#diff-46060d839f0f7a28fbbd62e804759e73ae04319edaecd7b7a55a244ffbb8a8f6R1-R23) [[2]](diffhunk://#diff-e1a30d0d797f027bf77707fa8330f5c44040a330c60195433505a7a1cb3f9e58R3-R6)

**Styling and UI Enhancements:**

* Added new styles for the acronym generator panel and improved the visual presentation of the interactive expansion component.

**Component and Modal Updates:**

* Updated the About modal to display a random HAI expansion instead of a static organization name, and to use the new expansion logic on initialization. [[1]](diffhunk://#diff-df9063c993a3e809cd675084ccd5c8853f2bcbef7d6d6d1e575aa03a4b7981abL2-R6) [[2]](diffhunk://#diff-df9063c993a3e809cd675084ccd5c8853f2bcbef7d6d6d1e575aa03a4b7981abL14-R15) [[3]](diffhunk://#diff-df9063c993a3e809cd675084ccd5c8853f2bcbef7d6d6d1e575aa03a4b7981abR27-R31) [[4]](diffhunk://#diff-f9c2f01fb1e87d0408aef17e14ab03a0d1339c4a26e54b8ad68cb0b3c9a43d5eL18-R22)

**Documentation Update:**

* Updated project guidelines documentation to reflect the new branding and playful approach to the HAI acronym.