### PR TITLE
update deployment matrix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -112,25 +112,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: cjrutherford/optimistic_tanuki_${{ matrix.app }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=prod,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./apps/${{ matrix.app }}/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
       - name: Install pnpm
         if: matrix.type == 'service'
         uses: pnpm/action-setup@v4
@@ -149,3 +130,22 @@ jobs:
       - name: Build Nx Projects
         if: matrix.type == 'service'
         run: pnpm exec nx build ${{ matrix.app }} --configuration=production
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: cjrutherford/optimistic_tanuki_${{ matrix.app }}
+          tags: |
+            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=prod,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./apps/${{ matrix.app }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,23 +9,92 @@ permissions:
   contents: read
 
 jobs:
-  # SSR Angular apps that build themselves (multi-stage Dockerfiles)
-  build_and_push_ssr_apps:
-    name: Build and Push ${{ matrix.service }}
+  build_and_push:
+    name: Build and Push ${{ matrix.app }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        service:
-          [
-            client-interface,
-            forgeofwill,
-            christopherrutherford-net,
-            digital-homestead,
-            fin-commander,
-            business-site,
-          ]
+        include:
+          - app: ai-orchestrator
+            type: service
+          - app: app-configurator
+            type: service
+          - app: assets
+            type: service
+          - app: authentication
+            type: service
+          - app: blogging
+            type: service
+          - app: business-site
+            type: client
+          - app: chat-collector
+            type: service
+          - app: christopherrutherford-net
+            type: client
+          - app: classifieds
+            type: service
+          - app: client-interface
+            type: client
+          - app: configurable-client
+            type: client
+          - app: d6
+            type: client
+          - app: digital-homestead
+            type: client
+          - app: fin-commander
+            type: client
+          - app: finance
+            type: service
+          - app: forgeofwill
+            type: client
+          - app: forum
+            type: service
+          - app: gateway
+            type: service
+          - app: hai
+            type: client
+          - app: lead-tracker
+            type: service
+          - app: leads-app
+            type: client
+          - app: local-hub
+            type: client
+          - app: marketing-generator
+            type: client
+          - app: owner-console
+            type: client
+          - app: payments
+            type: service
+          - app: permissions
+            type: service
+          - app: profile
+            type: service
+          - app: project-planning
+            type: service
+          - app: prompt-proxy
+            type: service
+          - app: social
+            type: service
+          - app: store
+            type: service
+          - app: store-client
+            type: client
+          - app: system-configurator
+            type: client
+          - app: system-configurator-api
+            type: service
+          - app: telos-docs-service
+            type: service
+          - app: video-client
+            type: client
+          - app: video-transcoder-worker
+            type: service
+          - app: videos
+            type: service
+          - app: wellness
+            type: service
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -47,7 +116,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: cjrutherford/optimistic_tanuki_${{ matrix.service }}
+          images: cjrutherford/optimistic_tanuki_${{ matrix.app }}
           tags: |
             type=ref,event=branch
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -57,85 +126,26 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./apps/${{ matrix.service }}/Dockerfile
+          file: ./apps/${{ matrix.app }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-  # Backend services that need pre-built artifacts
-  build_and_push_backend_services:
-    name: Build and Push ${{ matrix.service }}
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        service:
-          [
-            assets,
-            authentication,
-            social,
-            profile,
-            gateway,
-            project-planning,
-            chat-collector,
-            prompt-proxy,
-            ai-orchestrator,
-            telos-docs-service,
-            blogging,
-            finance,
-          ]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
 
       - name: Install pnpm
+        if: matrix.type == 'service'
         uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
+        if: matrix.type == 'service'
         uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["mirror.gcr.io"]
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Install Dependencies
-        id: install
-        run: |
-          echo "Installing dependencies for service: ${{ matrix.service }}"
-          pnpm install --frozen-lockfile
-      - name: Build Nx Projects
-        id: build
-        run: |
-          echo "Building Nx project for service: ${{ matrix.service }}"
-          pnpm exec nx build ${{ matrix.service }} --configuration=production
-          ls -lath && pwd
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: cjrutherford/optimistic_tanuki_${{ matrix.service }}
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=prod,enable=${{ github.ref == 'refs/heads/main' }}
+        if: matrix.type == 'service'
+        run: pnpm install --frozen-lockfile
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./apps/${{ matrix.service }}/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build Nx Projects
+        if: matrix.type == 'service'
+        run: pnpm exec nx build ${{ matrix.app }} --configuration=production

--- a/scripts/validate-deployment-inventory.mjs
+++ b/scripts/validate-deployment-inventory.mjs
@@ -122,13 +122,21 @@ const composeContent = fs.readFileSync(
   path.join(repoRoot, 'docker-compose.yaml'),
   'utf8'
 );
-const composeImageNames = [
+const composeImageMatches = [
   ...composeContent.matchAll(
-    /image:\s*(cjrutherford\/optimistic_tanuki_[^:\s]+):\$\{PRODUCTION_IMAGE_TAG:-latest\}/g
+    /image:\s*(cjrutherford\/optimistic_tanuki_[^:\s]+)(?::([^\s]+))?/g
   ),
-].map((match) => match[1]);
+];
+const composeImageNames = composeImageMatches.map((match) => match[1]);
+const invalidComposeImageTags = composeImageMatches
+  .filter((match) => match[2] !== '${PRODUCTION_IMAGE_TAG:-latest}')
+  .map((match) =>
+    match[2]
+      ? `${match[1]} uses unexpected tag "${match[2]}"`
+      : `${match[1]} is missing a tag`
+  );
 const uniqueComposeImageNames = [...new Set(composeImageNames)].sort();
-const expectedComposeImageNames = expectedImageNames.sort();
+const expectedComposeImageNames = [...expectedImageNames];
 const expectedComposeServices = inventory.apps
   .map((app) => app.ComposeServiceName || app.ID)
   .sort();
@@ -140,6 +148,7 @@ errors.push(
     uniqueComposeImageNames
   )
 );
+errors.push(...invalidComposeImageTags);
 
 errors.push(
   ...compareRequiredList(

--- a/scripts/validate-deployment-inventory.mjs
+++ b/scripts/validate-deployment-inventory.mjs
@@ -75,6 +75,15 @@ const matrixApps = buildPush.jobs['build-and-push'].strategy.matrix.include
   .map((entry) => entry.app)
   .sort();
 
+const dockerPublish = readYaml(
+  path.join(repoRoot, '.github/workflows/docker-publish.yml')
+);
+const dockerPublishApps = dockerPublish.jobs[
+  'build_and_push'
+].strategy.matrix.include
+  .map((entry) => entry.app)
+  .sort();
+
 const baseKustomization = readYaml(
   path.join(repoRoot, 'k8s/base/kustomization.yaml')
 );
@@ -98,6 +107,7 @@ const expectedImageNames = inventory.apps.map((app) => app.ImageName).sort();
 
 const errors = [
   ...compareList('build-push matrix apps', expectedApps, matrixApps),
+  ...compareList('docker-publish matrix apps', expectedApps, dockerPublishApps),
   ...compareList(
     'base kustomization resources',
     expectedResources,
@@ -108,9 +118,28 @@ const errors = [
 const packageJson = JSON.parse(
   fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
 );
+const composeContent = fs.readFileSync(
+  path.join(repoRoot, 'docker-compose.yaml'),
+  'utf8'
+);
+const composeImageNames = [
+  ...composeContent.matchAll(
+    /image:\s*(cjrutherford\/optimistic_tanuki_[^:\s]+):\$\{PRODUCTION_IMAGE_TAG:-latest\}/g
+  ),
+].map((match) => match[1]);
+const uniqueComposeImageNames = [...new Set(composeImageNames)].sort();
+const expectedComposeImageNames = expectedImageNames.sort();
 const expectedComposeServices = inventory.apps
   .map((app) => app.ComposeServiceName || app.ID)
   .sort();
+
+errors.push(
+  ...compareList(
+    'docker-compose image names',
+    expectedComposeImageNames,
+    uniqueComposeImageNames
+  )
+);
 
 errors.push(
   ...compareRequiredList(


### PR DESCRIPTION
This pull request refactors and consolidates the Docker build and publish GitHub Actions workflow to use a single, unified job for building and pushing all app and service images. Additionally, it updates the deployment inventory validation script to ensure consistency between the deployment inventory, the Docker workflow, and the docker-compose configuration.

Most important changes:

**GitHub Actions Workflow Consolidation and Refactor:**

* Merged the previously separate `build_and_push_ssr_apps` and `build_and_push_backend_services` jobs into a single `build_and_push` job in `.github/workflows/docker-publish.yml`, using a unified matrix with both app name and type (`service` or `client`). This simplifies the workflow and reduces duplication.
* Updated all references in the workflow from `matrix.service` to `matrix.app` to align with the new matrix structure. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L50-R119) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L60-R151)
* Added conditional steps in the workflow so that dependency installation and build steps are only run for entries with `type: service`, ensuring client apps are handled appropriately.

**Deployment Inventory Validation Improvements:**

* Updated `scripts/validate-deployment-inventory.mjs` to read the new `build_and_push` job matrix from the Docker workflow, and compare its apps against the deployment inventory for consistency. [[1]](diffhunk://#diff-599d6111781cafb7f9a08ff8d5fbfe76593bb5d531b6a421635886d79a3dcb3eR78-R86) [[2]](diffhunk://#diff-599d6111781cafb7f9a08ff8d5fbfe76593bb5d531b6a421635886d79a3dcb3eR110)
* Enhanced the validation script to also check that the image names used in `docker-compose.yaml` match those defined in the deployment inventory, catching mismatches early.