### PR TITLE
fix business seed on prod envs

### DIFF
--- a/scripts/prod-seed.sh
+++ b/scripts/prod-seed.sh
@@ -7,6 +7,7 @@ GATEWAY_API_URL="${GATEWAY_API_URL:-http://gateway:3000/api}"
 GATEWAY_BASE_URL="${GATEWAY_BASE_URL:-http://gateway:3000}"
 HOST_GATEWAY_BASE_URL="${HOST_GATEWAY_BASE_URL:-http://127.0.0.1:3000}"
 APP_RUNTIME_DIR="/usr/src/app"
+BUSINESS_SITE_RUNTIME_DIR="/app"
 
 compose_cmd() {
   if [ -n "$COMPOSE_ENV_FILE" ]; then
@@ -98,7 +99,7 @@ echo "Seeding social service (including local communities)..."
 run_seed social "${APP_RUNTIME_DIR}" node ./seed-local-communities.js
 
 echo "Seeding business-site service (including seeded businesses and client workflows)..."
-run_seed_with_env business-site "${APP_RUNTIME_DIR}" GATEWAY_URL "${GATEWAY_API_URL}" node ./apps/business-site/src/seed-trainer.mjs
+run_seed_with_env business-site "${BUSINESS_SITE_RUNTIME_DIR}" GATEWAY_URL "${GATEWAY_API_URL}" node ./seed-business.mjs
 
 echo ""
 echo "=========================================="

--- a/scripts/run-seed.sh
+++ b/scripts/run-seed.sh
@@ -120,14 +120,14 @@ main() {
                 telos-docs) run_seed_k8s "telos-docs-service" "node /usr/src/app/seed-persona.js" ;;
                 store) run_seed_k8s "store" "node /usr/src/app/seed-store.js" ;;
                 app-configurator) run_seed_k8s "app-configurator" "node seed-data/seed-script.js" ;;
-                business-site) run_seed_k8s "business-site" "GATEWAY_URL=http://gateway:3000/api node /usr/src/app/apps/business-site/src/seed-trainer.mjs" ;;
+                business-site) run_seed_k8s "business-site" "GATEWAY_URL=http://gateway:3000/api node /app/seed-business.mjs" ;;
                 all)
                     run_seed_k8s "permissions" "node /usr/src/app/seed-permissions.js"
                     run_seed_k8s "social" "node /usr/src/app/seed-local-communities.js"
                     run_seed_k8s "telos-docs-service" "node /usr/src/app/seed-persona.js"
                     run_seed_k8s "store" "node /usr/src/app/seed-store.js"
                     run_seed_k8s "app-configurator" "node seed-data/seed-script.js"
-                    run_seed_k8s "business-site" "GATEWAY_URL=http://gateway:3000/api node /usr/src/app/apps/business-site/src/seed-trainer.mjs"
+                    run_seed_k8s "business-site" "GATEWAY_URL=http://gateway:3000/api node /app/seed-business.mjs"
                     ;;
                 *) echo "Invalid seed choice"; exit 1 ;;
             esac
@@ -140,14 +140,14 @@ main() {
                 telos-docs) run_seed_docker "telos-docs-service" "node /usr/src/app/seed-persona.js" ;;
                 store) run_seed_docker "store" "node /usr/src/app/seed-store.js" ;;
                 app-configurator) run_seed_docker "app-configurator" "node seed-data/seed-script.js" ;;
-                business-site) run_seed_docker "business-site" "GATEWAY_URL=http://gateway:3000/api node /usr/src/app/apps/business-site/src/seed-trainer.mjs" ;;
+                business-site) run_seed_docker "business-site" "GATEWAY_URL=http://gateway:3000/api node /app/seed-business.mjs" ;;
                 all)
                     run_seed_docker "permissions" "node /usr/src/app/seed-permissions.js"
                     run_seed_docker "social" "node /usr/src/app/seed-local-communities.js"
                     run_seed_docker "telos-docs-service" "node /usr/src/app/seed-persona.js"
                     run_seed_docker "store" "node /usr/src/app/seed-store.js"
                     run_seed_docker "app-configurator" "node seed-data/seed-script.js"
-                    run_seed_docker "business-site" "GATEWAY_URL=http://gateway:3000/api node /usr/src/app/apps/business-site/src/seed-trainer.mjs"
+                    run_seed_docker "business-site" "GATEWAY_URL=http://gateway:3000/api node /app/seed-business.mjs"
                     ;;
                 *) echo "Invalid seed choice"; exit 1 ;;
             esac
@@ -160,14 +160,14 @@ main() {
                 telos-docs) run_seed_local "telos-docs-service" "node src/app/seed-persona.js" ;;
                 store) run_seed_local "store" "node src/seed-store.js" ;;
                 app-configurator) run_seed_local "app-configurator" "node src/seed-data/seed-script.js" ;;
-                business-site) run_seed_local "business-site" "GATEWAY_URL=http://gateway:3000/api node src/seed-trainer.mjs" ;;
+                business-site) run_seed_local "business-site" "GATEWAY_URL=http://gateway:3000/api node src/seed-business.mjs" ;;
                 all)
                     run_seed_local "permissions" "node src/app/seed-permissions.js"
                     run_seed_local "social" "node src/seed-social.js"
                     run_seed_local "telos-docs-service" "node src/app/seed-persona.js"
                     run_seed_local "store" "node src/seed-store.js"
                     run_seed_local "app-configurator" "node src/seed-data/seed-script.js"
-                    run_seed_local "business-site" "GATEWAY_URL=http://gateway:3000/api node src/seed-trainer.mjs"
+                    run_seed_local "business-site" "GATEWAY_URL=http://gateway:3000/api node src/seed-business.mjs"
                     ;;
                 *) echo "Invalid seed choice"; exit 1 ;;
             esac

--- a/scripts/tests/docker-service-planner.test.mjs
+++ b/scripts/tests/docker-service-planner.test.mjs
@@ -242,3 +242,20 @@ test('dev-seed.sh refreshes videos before seeding it', () => {
     'expected videos refresh to happen before videos seed'
   );
 });
+
+test('prod and generic seed scripts use the business-site seed entrypoint', () => {
+  const prodScript = fs.readFileSync(
+    path.join(repoRoot, 'scripts', 'prod-seed.sh'),
+    'utf8'
+  );
+  const genericScript = fs.readFileSync(
+    path.join(repoRoot, 'scripts', 'run-seed.sh'),
+    'utf8'
+  );
+
+  assert.match(prodScript, /node \.\/seed-business\.mjs/);
+  assert.doesNotMatch(prodScript, /seed-trainer\.mjs/);
+
+  assert.match(genericScript, /node \/app\/seed-business\.mjs/);
+  assert.doesNotMatch(genericScript, /business-site.*seed-trainer\.mjs/);
+});


### PR DESCRIPTION
This pull request updates the seeding process for the `business-site` service to use a new entrypoint script, `seed-business.mjs`, instead of the previous `seed-trainer.mjs`. It also introduces a new runtime directory variable and includes tests to ensure the correct script is used. The changes improve consistency across production, Docker, Kubernetes, and local environments.

**Seeding process updates:**

* Changed all references to the `business-site` seed entrypoint from `seed-trainer.mjs` to `seed-business.mjs` in `prod-seed.sh` and `run-seed.sh`, ensuring the new script is used for seeding businesses and workflows in all environments. [[1]](diffhunk://#diff-9c28f6c714346ce1267f8e52225d44045dee4b75cc7c897061292e4c03145b89L101-R102) [[2]](diffhunk://#diff-d31509299a01b24e3e8a400ee9dfcfdb96d3c1217d28bd1b6a239cf09503de94L123-R130) [[3]](diffhunk://#diff-d31509299a01b24e3e8a400ee9dfcfdb96d3c1217d28bd1b6a239cf09503de94L143-R150) [[4]](diffhunk://#diff-d31509299a01b24e3e8a400ee9dfcfdb96d3c1217d28bd1b6a239cf09503de94L163-R170)

**Configuration improvements:**

* Introduced the `BUSINESS_SITE_RUNTIME_DIR` variable in `prod-seed.sh` to specify the runtime directory for the business-site service, improving clarity and maintainability.

**Testing enhancements:**

* Added a test in `docker-service-planner.test.mjs` to verify that both the production and generic seed scripts use `seed-business.mjs` and no longer reference `seed-trainer.mjs`.