### PR TITLE
add sample tenants to business site docker and fix gateway cross orig…

### DIFF
--- a/apps/business-site/Dockerfile
+++ b/apps/business-site/Dockerfile
@@ -42,6 +42,7 @@ COPY --from=builder /usr/src/app/apps/business-site/src/seed-trainer.mjs /app/se
 COPY --from=builder /usr/src/app/docs/guides/business-site-evaluator-guide.html /app/docs/guides/business-site-evaluator-guide.html
 COPY --from=builder /usr/src/app/apps/business-site/src/seed-trainer.mjs /app/apps/business-site/src/seed-trainer.mjs
 COPY --from=builder /usr/src/app/apps/business-site/src/seed-business.mjs /app/apps/business-site/src/seed-business.mjs
+COPY --from=builder /usr/src/app/apps/business-site/src/sample-tenants.mjs /app/sample-tenants.mjs
 COPY --from=builder /usr/src/app/apps/business-site/src/sample-tenants.mjs /app/apps/business-site/src/sample-tenants.mjs
 
 RUN echo '#!/bin/sh' > /docker-entrypoint.sh && \

--- a/apps/gateway/src/bootstrap/security.spec.ts
+++ b/apps/gateway/src/bootstrap/security.spec.ts
@@ -3,6 +3,7 @@ import {
   applyGatewaySecurityHeaders,
   enforceTrustedBrowserOrigins,
   isAllowedOrigin,
+  isProxiedRequest,
   shouldRejectBrowserMutation,
 } from './security';
 
@@ -86,6 +87,34 @@ describe('gateway security helpers', () => {
       "default-src 'none'"
     );
     expect(next).toHaveBeenCalled();
+  });
+
+  it('allows proxied browser mutations regardless of origin', () => {
+    expect(
+      shouldRejectBrowserMutation(
+        createRequest({
+          headers: {
+            origin: 'https://client.example.com',
+            'x-forwarded-host': 'client.example.com',
+            'x-forwarded-proto': 'https',
+            'sec-fetch-site': 'cross-site',
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('identifies proxied requests', () => {
+    expect(
+      isProxiedRequest(
+        createRequest({
+          headers: {
+            'x-forwarded-host': 'client.example.com',
+            'x-forwarded-proto': 'https',
+          },
+        })
+      )
+    ).toBe(true);
   });
 
   it('blocks rejected browser mutations', () => {

--- a/apps/gateway/src/bootstrap/security.ts
+++ b/apps/gateway/src/bootstrap/security.ts
@@ -65,10 +65,20 @@ export const getRequestOrigin = (request: Request): string => {
   return `${proto}://${host}`;
 };
 
+export const isProxiedRequest = (request: Request): boolean => {
+  return !!(
+    request.get('x-forwarded-host') || request.get('x-forwarded-proto')
+  );
+};
+
 export const shouldRejectBrowserMutation = (
   request: Request,
   configuredOrigins = parseConfiguredOrigins()
 ): boolean => {
+  if (isProxiedRequest(request)) {
+    return false;
+  }
+
   if (!UNSAFE_HTTP_METHODS.has(request.method.toUpperCase())) {
     return false;
   }


### PR DESCRIPTION
This pull request introduces improvements to the gateway's security logic, particularly around handling proxied requests, and makes a minor update to the business-site Dockerfile. The most significant changes are the introduction of the `isProxiedRequest` helper and the adjustment of browser mutation rejection logic to account for proxied requests.

**Gateway security logic improvements:**

* Added a new `isProxiedRequest` function in `security.ts` to detect requests that have proxy headers (`x-forwarded-host` or `x-forwarded-proto`).
* Updated `shouldRejectBrowserMutation` to allow browser mutations if the request is proxied, regardless of origin, improving compatibility with trusted proxies.
* Added tests in `security.spec.ts` to verify that proxied requests are identified and that proxied browser mutations are allowed.
* Imported the new `isProxiedRequest` helper in the security test suite.

**Dockerfile update:**

* Added a line to the `business-site` Dockerfile to copy `sample-tenants.mjs` to `/app/sample-tenants.mjs`, ensuring the file is available in the correct location in the container.…in issues