### PR TITLE
tweaked detection algorithm.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -140,7 +140,7 @@ jobs:
     name: Retag unchanged apps on main
     runs-on: ubuntu-24.04
     needs: [determine_changes]
-    if: ${{ needs.determine_changes.outputs.has_changes == 'true' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.determine_changes.outputs.has_changes == 'true' && needs.determine_changes.outputs.unchanged_apps != '[]' && github.ref == 'refs/heads/main' }}
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/resolve-docker-changes.mjs
+++ b/scripts/resolve-docker-changes.mjs
@@ -46,17 +46,44 @@ function resolveComposeServices(composeFile) {
   return services;
 }
 
+function resolvePlanApps(plan, composeFile) {
+  const planApps = [
+    ...new Set(
+      Object.values(plan.services || {})
+        .map((service) => service?.appId)
+        .filter(Boolean)
+    ),
+  ].sort();
+
+  if (planApps.length > 0) {
+    return planApps;
+  }
+
+  return resolveComposeServices(composeFile);
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const plan = JSON.parse(fs.readFileSync(args.planFile, 'utf8'));
   const changedApps = [...new Set(plan.buildApps || [])].sort();
-  const allApps = resolveComposeServices(args.composeFile);
+  const allApps = resolvePlanApps(plan, args.composeFile);
   const changedSet = new Set(changedApps);
   const unchangedApps = allApps.filter((app) => !changedSet.has(app));
 
   const matrix = JSON.stringify(changedApps);
   const hasChanges = changedApps.length > 0 ? 'true' : 'false';
   const unchangedAppSet = JSON.stringify(unchangedApps);
+
+  console.log(
+    `Changed apps: ${
+      changedApps.length > 0 ? changedApps.join(', ') : '(none)'
+    }`
+  );
+  console.log(
+    `Unchanged apps: ${
+      unchangedApps.length > 0 ? unchangedApps.join(', ') : '(none)'
+    }`
+  );
 
   const outputFile = process.env.GITHUB_OUTPUT;
   if (outputFile) {

--- a/scripts/tests/docker-service-planner.test.mjs
+++ b/scripts/tests/docker-service-planner.test.mjs
@@ -174,6 +174,62 @@ test('createComposeBuildPlan respects selected service filters', async () => {
   assert.ok(!('client-interface' in plan.services));
 });
 
+test('resolve-docker-changes excludes non-buildable compose services from unchanged apps', () => {
+  const planFile = path.join(
+    os.tmpdir(),
+    `docker-plan-resolve-${process.pid}.json`
+  );
+  const outputFile = path.join(
+    os.tmpdir(),
+    `docker-plan-resolve-output-${process.pid}.txt`
+  );
+  fs.writeFileSync(outputFile, '');
+  fs.writeFileSync(
+    planFile,
+    JSON.stringify({
+      buildApps: ['authentication'],
+      services: {
+        authentication: { appId: 'authentication' },
+        gateway: { appId: 'gateway' },
+        'client-interface': { appId: 'client-interface' },
+      },
+    })
+  );
+
+  const result = spawnSync(
+    'bash',
+    [
+      '-lc',
+      `node scripts/resolve-docker-changes.mjs --plan-file "${planFile}" --compose-file docker-compose.yaml`,
+    ],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputFile,
+      },
+      encoding: 'utf8',
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const outputs = fs.readFileSync(outputFile, 'utf8');
+  assert.match(outputs, /matrix=\["authentication"\]/);
+  assert.match(outputs, /unchanged_apps=\["client-interface","gateway"\]/);
+  assert.doesNotMatch(outputs, /postgres/);
+  assert.doesNotMatch(outputs, /redis/);
+});
+
+test('resolve-docker-changes includes workflow logging for changed and unchanged apps', () => {
+  const script = fs.readFileSync(
+    path.join(repoRoot, 'scripts/resolve-docker-changes.mjs'),
+    'utf8'
+  );
+
+  assert.match(script, /Changed apps:/);
+  assert.match(script, /Unchanged apps:/);
+});
+
 test('docker-build-batched.sh defaults to batch size 10', () => {
   const bakeFile = path.join(os.tmpdir(), `docker-bake-${process.pid}.json`);
   fs.writeFileSync(


### PR DESCRIPTION
This pull request improves the logic for determining which Docker Compose apps are considered "unchanged" in CI workflows and enhances the related test coverage and logging. The main focus is to ensure that only buildable apps are included in the unchanged apps list, preventing non-buildable services like databases from being incorrectly processed. Additionally, it adds more informative logging and tests to verify the new behavior.

**Improvements to unchanged apps detection:**

* Updated the workflow condition in `.github/workflows/docker-publish.yml` to only run the "Retag unchanged apps" job if there are actually unchanged apps, preventing unnecessary job runs.
* Refactored `scripts/resolve-docker-changes.mjs` to use a new `resolvePlanApps` function, which determines the list of apps from the build plan and excludes non-buildable compose services from the unchanged apps output.

**Logging and test enhancements:**

* Added workflow logging to `scripts/resolve-docker-changes.mjs` to print out which apps are changed and which are unchanged, making CI output more informative.
* Added new tests in `scripts/tests/docker-service-planner.test.mjs` to verify that non-buildable services are excluded from unchanged apps and that logging output is present.