### PR TITLE
replace snake case with camel case for secrets

### DIFF
--- a/apps/gateway/src/app/app.module.ts
+++ b/apps/gateway/src/app/app.module.ts
@@ -372,7 +372,15 @@ const realtimeProviderEntries: Array<ValueComposableEntry<any>> =
     {
       provide: JwtService,
       useFactory: (config: ConfigService) => {
-        const secret = config.get('auth.jwtSecret') || 'default_jwt_secret';
+        const secret =
+          config.get<string>('auth.jwtSecret') ??
+          config.get<string>('auth.jwt_secret');
+
+        if (!secret) {
+          throw new Error(
+            'JWT secret is not configured; set JWT_SECRET or auth.jwtSecret'
+          );
+        }
         return new JwtService({ secret });
       },
       inject: [ConfigService],

--- a/apps/gateway/src/app/app.module.ts
+++ b/apps/gateway/src/app/app.module.ts
@@ -372,7 +372,7 @@ const realtimeProviderEntries: Array<ValueComposableEntry<any>> =
     {
       provide: JwtService,
       useFactory: (config: ConfigService) => {
-        const secret = config.get('auth.jwt_secret') || 'default_jwt_secret';
+        const secret = config.get('auth.jwtSecret') || 'default_jwt_secret';
         return new JwtService({ secret });
       },
       inject: [ConfigService],


### PR DESCRIPTION
This pull request makes a small update to the JWT service configuration in `app.module.ts`, ensuring that the correct configuration key is used for the JWT secret.

* Updated the `JwtService` provider to use the `auth.jwtSecret` configuration key instead of `auth.jwt_secret` for retrieving the JWT secret.