### PR TITLE
• feat(auth): add shared OAuth callbacks to Angular clients

### DIFF
--- a/apps/business-configurator/src/app/app.routes.spec.ts
+++ b/apps/business-configurator/src/app/app.routes.spec.ts
@@ -1,6 +1,19 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { appRoutes } from './app.routes';
 
 describe('business-configurator appRoutes', () => {
+  it('registers the shared OAuth popup callback before the fallback route', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === '**'));
+  });
+
   it('loads the consolidated workspace in guided mode at the root path', () => {
     const rootRoute = appRoutes.find((route) => route.path === '');
 

--- a/apps/business-configurator/src/app/app.routes.ts
+++ b/apps/business-configurator/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   {
     path: '',
     title: 'Business Site Builder',

--- a/apps/business-site/src/app/app.routes.spec.ts
+++ b/apps/business-site/src/app/app.routes.spec.ts
@@ -1,3 +1,4 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { appRoutes } from './app.routes';
 import { bookingFeatureGuard } from './booking-feature.guard';
 import { clientAuthGuard } from './client-auth.guard';
@@ -7,6 +8,18 @@ import { invoicesFeatureGuard } from './invoices-feature.guard';
 import { ownerFinanceFeatureGuard } from './owner-finance-feature.guard';
 
 describe('appRoutes', () => {
+  it('registers the shared OAuth popup callback before application routes', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === ''));
+  });
+
   it('exposes public, client, and owner route families', () => {
     expect(appRoutes.map((route) => route.path)).toEqual(
       expect.arrayContaining([

--- a/apps/business-site/src/app/app.routes.ts
+++ b/apps/business-site/src/app/app.routes.ts
@@ -10,7 +10,10 @@ import { clientPortalFeatureGuard } from './client-portal-feature.guard';
 import { clientTasksFeatureGuard } from './client-tasks-feature.guard';
 import { invoicesFeatureGuard } from './invoices-feature.guard';
 import { ownerFinanceFeatureGuard } from './owner-finance-feature.guard';
-import { emailAuthRoutes } from '@optimistic-tanuki/auth-ui';
+import {
+  emailAuthRoutes,
+  oauthCallbackRoutes,
+} from '@optimistic-tanuki/auth-ui';
 
 const ownerFinanceConfig = {
   routeBase: '/owner/finance',
@@ -118,6 +121,7 @@ const clientChildren: Route[] = [
 ];
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   ...emailAuthRoutes('business-site:token'),
   {
     path: '',

--- a/apps/christopherrutherford-net/src/app/app.routes.spec.ts
+++ b/apps/christopherrutherford-net/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
+import { appRoutes } from './app.routes';
+
+describe('christopherrutherford-net appRoutes', () => {
+  it('registers the shared OAuth popup callback before the landing fallback', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === '**'));
+  });
+});

--- a/apps/christopherrutherford-net/src/app/app.routes.ts
+++ b/apps/christopherrutherford-net/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   {
     path: 'forum',
     loadChildren: () =>

--- a/apps/configurable-client/src/app/app.routes.spec.ts
+++ b/apps/configurable-client/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
+import { appRoutes } from './app.routes';
+
+describe('configurable-client appRoutes', () => {
+  it('registers the shared OAuth popup callback before the root resolver', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === ''));
+  });
+});

--- a/apps/configurable-client/src/app/app.routes.ts
+++ b/apps/configurable-client/src/app/app.routes.ts
@@ -1,8 +1,10 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { LandingPageComponent } from './components/landing-page.component';
 import { AppResolverComponent } from './components/app-resolver.component';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   {
     path: 'app/:appName',
     component: AppResolverComponent,

--- a/apps/developer-portal/src/app/app.routes.spec.ts
+++ b/apps/developer-portal/src/app/app.routes.spec.ts
@@ -1,0 +1,13 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
+import { appRoutes } from './app.routes';
+
+describe('developer-portal appRoutes', () => {
+  it('registers the shared OAuth popup callback', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+  });
+});

--- a/apps/developer-portal/src/app/app.routes.ts
+++ b/apps/developer-portal/src/app/app.routes.ts
@@ -1,3 +1,4 @@
 import { Routes } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 
-export const appRoutes: Routes = [];
+export const appRoutes: Routes = [...oauthCallbackRoutes];

--- a/apps/hai/src/app/app.routes.spec.ts
+++ b/apps/hai/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
+import { appRoutes } from './app.routes';
+
+describe('hai appRoutes', () => {
+  it('registers the shared OAuth popup callback before the landing page', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === ''));
+  });
+});

--- a/apps/hai/src/app/app.routes.ts
+++ b/apps/hai/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   {
     path: '',
     loadComponent: () =>

--- a/apps/marketing-generator/src/app/app.routes.spec.ts
+++ b/apps/marketing-generator/src/app/app.routes.spec.ts
@@ -1,6 +1,19 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { appRoutes } from './app.routes';
 
 describe('appRoutes', () => {
+  it('registers the shared OAuth popup callback before the fallback route', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === '**'));
+  });
+
   it('exposes landing, offer index, offer brief, and offer workspace routes', () => {
     expect(appRoutes.map((route) => route.path)).toEqual(
       expect.arrayContaining([

--- a/apps/marketing-generator/src/app/app.routes.ts
+++ b/apps/marketing-generator/src/app/app.routes.ts
@@ -1,6 +1,8 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   {
     path: '',
     loadComponent: () =>

--- a/apps/setup-console/src/app/app.routes.spec.ts
+++ b/apps/setup-console/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
+import { appRoutes } from './app.routes';
+
+describe('setup-console appRoutes', () => {
+  it('registers the shared OAuth popup callback before setup routes', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === ''));
+  });
+});

--- a/apps/setup-console/src/app/app.routes.ts
+++ b/apps/setup-console/src/app/app.routes.ts
@@ -1,7 +1,9 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { BootstrapOnboardingComponent } from './components/bootstrap-onboarding.component';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   { path: '', component: BootstrapOnboardingComponent },
   { path: 'setup', component: BootstrapOnboardingComponent },
 ];

--- a/apps/store-client/src/app/app.routes.spec.ts
+++ b/apps/store-client/src/app/app.routes.spec.ts
@@ -1,0 +1,16 @@
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
+import { appRoutes } from './app.routes';
+
+describe('store-client appRoutes', () => {
+  it('registers the shared OAuth popup callback before the root redirect', () => {
+    expect(appRoutes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(appRoutes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      appRoutes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(appRoutes.findIndex((route) => route.path === ''));
+  });
+});

--- a/apps/store-client/src/app/app.routes.ts
+++ b/apps/store-client/src/app/app.routes.ts
@@ -1,10 +1,12 @@
 import { Route } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { CatalogComponent } from './pages/catalog/catalog.component';
 import { CartComponent } from './pages/cart/cart.component';
 import { DonationsComponent } from './pages/donations/donations.component';
 import { BookingsComponent } from './pages/bookings/bookings.component';
 
 export const appRoutes: Route[] = [
+  ...oauthCallbackRoutes,
   { path: '', redirectTo: '/catalog', pathMatch: 'full' },
   { path: 'catalog', component: CatalogComponent },
   { path: 'cart', component: CartComponent },

--- a/apps/ui-playground/public/generated/compodoc-index.json
+++ b/apps/ui-playground/public/generated/compodoc-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-21T18:57:14.892Z",
+  "generatedAt": "2026-07-22T13:53:18.252Z",
   "items": [
     {
       "slug": "motion-ui",
@@ -12,7 +12,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/motion-ui",
       "url": "/generated/compodoc/motion-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.877Z"
+      "generatedAt": "2026-07-22T13:53:18.232Z"
     },
     {
       "slug": "common-ui",
@@ -25,7 +25,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/common-ui",
       "url": "/generated/compodoc/common-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.881Z"
+      "generatedAt": "2026-07-22T13:53:18.235Z"
     },
     {
       "slug": "navigation-ui",
@@ -38,7 +38,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/navigation-ui",
       "url": "/generated/compodoc/navigation-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.881Z"
+      "generatedAt": "2026-07-22T13:53:18.235Z"
     },
     {
       "slug": "theme-ui",
@@ -51,7 +51,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/theme-ui",
       "url": "/generated/compodoc/theme-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.881Z"
+      "generatedAt": "2026-07-22T13:53:18.236Z"
     },
     {
       "slug": "form-ui",
@@ -64,7 +64,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/form-ui",
       "url": "/generated/compodoc/form-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.882Z"
+      "generatedAt": "2026-07-22T13:53:18.238Z"
     },
     {
       "slug": "notification-ui",
@@ -77,7 +77,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/notification-ui",
       "url": "/generated/compodoc/notification-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.882Z"
+      "generatedAt": "2026-07-22T13:53:18.238Z"
     },
     {
       "slug": "store-ui",
@@ -90,7 +90,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/store-ui",
       "url": "/generated/compodoc/store-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.883Z"
+      "generatedAt": "2026-07-22T13:53:18.239Z"
     },
     {
       "slug": "auth-ui",
@@ -103,7 +103,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/auth-ui",
       "url": "/generated/compodoc/auth-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.883Z"
+      "generatedAt": "2026-07-22T13:53:18.240Z"
     },
     {
       "slug": "profile-ui",
@@ -116,7 +116,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/profile-ui",
       "url": "/generated/compodoc/profile-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.884Z"
+      "generatedAt": "2026-07-22T13:53:18.241Z"
     },
     {
       "slug": "chat-ui",
@@ -129,7 +129,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/chat-ui",
       "url": "/generated/compodoc/chat-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.885Z"
+      "generatedAt": "2026-07-22T13:53:18.243Z"
     },
     {
       "slug": "message-ui",
@@ -142,7 +142,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/message-ui",
       "url": "/generated/compodoc/message-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.885Z"
+      "generatedAt": "2026-07-22T13:53:18.243Z"
     },
     {
       "slug": "search-ui",
@@ -155,7 +155,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/search-ui",
       "url": "/generated/compodoc/search-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.885Z"
+      "generatedAt": "2026-07-22T13:53:18.244Z"
     },
     {
       "slug": "persona-ui",
@@ -168,7 +168,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/persona-ui",
       "url": "/generated/compodoc/persona-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.885Z"
+      "generatedAt": "2026-07-22T13:53:18.244Z"
     },
     {
       "slug": "ag-grid-ui",
@@ -181,7 +181,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/ag-grid-ui",
       "url": "/generated/compodoc/ag-grid-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.885Z"
+      "generatedAt": "2026-07-22T13:53:18.245Z"
     },
     {
       "slug": "social-ui",
@@ -194,7 +194,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/social-ui",
       "url": "/generated/compodoc/social-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.887Z"
+      "generatedAt": "2026-07-22T13:53:18.246Z"
     },
     {
       "slug": "blogging-ui",
@@ -207,7 +207,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/blogging-ui",
       "url": "/generated/compodoc/blogging-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.888Z"
+      "generatedAt": "2026-07-22T13:53:18.247Z"
     },
     {
       "slug": "community-ui",
@@ -220,7 +220,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/community-ui",
       "url": "/generated/compodoc/community-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.889Z"
+      "generatedAt": "2026-07-22T13:53:18.249Z"
     },
     {
       "slug": "forum-ui",
@@ -233,7 +233,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/forum-ui",
       "url": "/generated/compodoc/forum-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.890Z"
+      "generatedAt": "2026-07-22T13:53:18.250Z"
     },
     {
       "slug": "project-ui",
@@ -246,7 +246,7 @@
       "outputPath": "apps/ui-playground/public/generated/compodoc/project-ui",
       "url": "/generated/compodoc/project-ui/index.html",
       "available": true,
-      "generatedAt": "2026-07-21T18:57:14.892Z"
+      "generatedAt": "2026-07-22T13:53:18.252Z"
     }
   ]
 }

--- a/apps/ui-playground/public/generated/docs-manifest.json
+++ b/apps/ui-playground/public/generated/docs-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-07-21T18:57:13.135Z",
+  "generatedAt": "2026-07-22T13:53:16.324Z",
   "items": [
     {
       "slug": "apps/authentication/readme",

--- a/apps/ui-playground/src/app/app.routes.spec.ts
+++ b/apps/ui-playground/src/app/app.routes.spec.ts
@@ -1,14 +1,30 @@
 import { docsSlugMatcher, routes } from './app.routes';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 import { NavSidebarComponent } from './shared';
 import { UrlSegment } from '@angular/router';
 
 describe('ui-playground routes', () => {
+  it('registers the shared OAuth popup callback before the docs matcher', () => {
+    expect(routes.map((route) => route.path)).toEqual(
+      expect.arrayContaining(['oauth/callback'])
+    );
+    expect(routes.find((route) => route.path === 'oauth/callback')).toBe(
+      oauthCallbackRoutes[0]
+    );
+    expect(
+      routes.findIndex((route) => route.path === 'oauth/callback')
+    ).toBeLessThan(
+      routes.findIndex((route) => route.matcher === docsSlugMatcher)
+    );
+  });
+
   it('includes the full curated library route set', () => {
     const libraryPaths = routes
       .map((route) => route.path)
       .filter((path): path is string => path !== undefined && path !== '**');
 
     expect(libraryPaths).toEqual([
+      'oauth/callback',
       '',
       'docs',
       'docs/api/:library',

--- a/apps/ui-playground/src/app/app.routes.ts
+++ b/apps/ui-playground/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes, UrlSegment } from '@angular/router';
+import { oauthCallbackRoutes } from '@optimistic-tanuki/auth-ui';
 
 export function docsSlugMatcher(
   segments: import('@angular/router').UrlSegment[]
@@ -22,6 +23,7 @@ export function docsSlugMatcher(
 }
 
 export const routes: Routes = [
+  ...oauthCallbackRoutes,
   {
     path: '',
     loadComponent: () =>

--- a/docs/plans/2026-07-22-oauth-client-callbacks.md
+++ b/docs/plans/2026-07-22-oauth-client-callbacks.md
@@ -1,0 +1,88 @@
+# Shared OAuth Client Callbacks Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable every production Angular client to receive the shared gateway OAuth completion at its same-origin `/oauth/callback` route, while provider callbacks remain anchored at Optimistic Tanuki's `/api/oauth/callback/:provider` endpoint.
+
+**Architecture:** Keep provider-to-gateway routing unchanged and use the shared `OAuthCallbackComponent` for the gateway-to-origin popup handoff. Export a reusable route constant from `auth-ui`; clients spread that constant into their route tables. Make the callback component’s API base optional with a `/api` fallback, because successful gateway completion only needs `postMessage` and several clients do not provide `API_BASE_URL`.
+
+**Tech Stack:** Angular standalone routing, `@optimistic-tanuki/auth-ui`, Jest, Nx.
+
+---
+
+### Task 1: Cover the shared callback route contract
+
+**Files:**
+
+- Modify: `libs/auth-ui/src/lib/oauth-callback/oauth-callback.component.spec.ts`
+- Modify: `libs/auth-ui/src/lib/auth-ui/index.ts`
+- Modify: `libs/auth-ui/src/lib/oauth-callback/oauth-callback.component.ts`
+
+**Step 1: Write failing tests**
+
+Add tests proving the reusable route exports `path: 'oauth/callback'` and `OAuthCallbackComponent`, and that the component can be constructed without an `API_BASE_URL` provider for the token handoff path.
+
+**Step 2: Run the focused auth-ui test through Nx**
+
+Run: `NX_DAEMON=false NX_ISOLATE_PLUGINS=false pnpm nx test auth-ui --runInBand`
+
+Expected: FAIL because the shared route export and optional provider behavior do not yet exist.
+
+**Step 3: Implement the minimal shared contract**
+
+Export a readonly callback route array from `auth-ui`; use an optional API base injection with `/api` as the direct-provider-callback fallback.
+
+**Step 4: Re-run the focused test**
+
+Run the same Nx test and confirm it passes.
+
+### Task 2: Register the shared callback route in every remaining Angular client
+
+**Files:**
+
+- Modify: `apps/business-configurator/src/app/app.routes.ts`
+- Modify: `apps/business-site/src/app/app.routes.ts`
+- Modify: `apps/christopherrutherford-net/src/app/app.routes.ts`
+- Modify: `apps/configurable-client/src/app/app.routes.ts`
+- Modify: `apps/developer-portal/src/app/app.routes.ts`
+- Modify: `apps/hai/src/app/app.routes.ts`
+- Modify: `apps/marketing-generator/src/app/app.routes.ts`
+- Modify: `apps/setup-console/src/app/app.routes.ts`
+- Modify: `apps/store-client/src/app/app.routes.ts`
+- Modify: `apps/ui-playground/src/app/app.routes.ts`
+- Test: app route specs where present; otherwise add a minimal route-contract spec.
+
+**Step 1: Write failing route-contract tests**
+
+For each remaining routed client, assert its route table contains `/oauth/callback` backed by the shared callback component.
+
+**Step 2: Run each focused app test through Nx**
+
+Run the applicable `pnpm nx test <app> --runInBand` commands with the required Nx environment variables; confirm the new assertions fail.
+
+**Step 3: Implement the route registrations**
+
+Import and spread the shared `oauthCallbackRoutes` constant before root routes with custom matchers or wildcard/fallback routes. Do not add any app-owned callback components or provider credentials.
+
+**Step 4: Re-run focused app tests**
+
+Confirm the route-contract tests pass.
+
+### Task 3: Verify the production client callback surface
+
+**Files:**
+
+- Verify: `tools/registry/apps.production.sample.yaml`
+- Verify: `apps/gateway/src/controllers/oauth/oauth.controller.ts`
+
+**Step 1: Run affected library and application tests through Nx**
+
+Run `auth-ui` plus all ten affected client projects with `NX_DAEMON=false NX_ISOLATE_PLUGINS=false`.
+
+**Step 2: Build the affected clients through Nx**
+
+Build each affected routed client with the same Nx environment flags.
+
+**Step 3: Inspect the final diff**
+
+Confirm the provider callback endpoint is not moved away from `optimistic-tanuki.com/api/oauth/callback/:provider`, and that every `uiBaseUrl` in the production registry resolves to a frontend callback route.

--- a/libs/auth-ui/src/lib/auth-ui/index.ts
+++ b/libs/auth-ui/src/lib/auth-ui/index.ts
@@ -4,4 +4,7 @@ export { MfaBlockComponent } from './mfa-block/mfa-block.component';
 export { ConfirmBlockComponent } from './confirm-block/confirm-block.component';
 export { OAuthButtonsComponent } from './oauth-buttons/oauth-buttons.component';
 export type { OAuthProviderEvent } from './oauth-buttons/oauth-buttons.component';
-export { OAuthCallbackComponent } from '../oauth-callback/oauth-callback.component';
+export {
+  OAuthCallbackComponent,
+  oauthCallbackRoutes,
+} from '../oauth-callback/oauth-callback.component';

--- a/libs/auth-ui/src/lib/oauth-callback/oauth-callback.component.spec.ts
+++ b/libs/auth-ui/src/lib/oauth-callback/oauth-callback.component.spec.ts
@@ -1,0 +1,94 @@
+import { DOCUMENT } from '@angular/common';
+import { PLATFORM_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+import { OAuthCallbackComponent, oauthCallbackRoutes } from '../../index';
+
+describe('OAuthCallbackComponent', () => {
+  it('exports the app-local OAuth callback route', () => {
+    expect(oauthCallbackRoutes).toEqual([
+      { path: 'oauth/callback', component: OAuthCallbackComponent },
+    ]);
+  });
+
+  it('can render without an API_BASE_URL provider', async () => {
+    await TestBed.configureTestingModule({
+      imports: [OAuthCallbackComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({}),
+            snapshot: { paramMap: { get: () => null } },
+          },
+        },
+        { provide: Router, useValue: { navigateByUrl: jest.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture: ComponentFixture<OAuthCallbackComponent> =
+      TestBed.createComponent(OAuthCallbackComponent);
+
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('relays a provider code through same-origin /api without an API_BASE_URL provider', async () => {
+    const location = {
+      search: '?code=authorization-code&state=oauth-state',
+      replace: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [OAuthCallbackComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({ code: 'authorization-code' }),
+            snapshot: { paramMap: { get: () => 'google' } },
+          },
+        },
+        { provide: Router, useValue: { navigateByUrl: jest.fn() } },
+        { provide: DOCUMENT, useValue: { location } },
+      ],
+    }).compileComponents();
+
+    TestBed.runInInjectionContext(() => {
+      new OAuthCallbackComponent(TestBed.inject(ActivatedRoute)).ngOnInit();
+    });
+
+    expect(location.replace).toHaveBeenCalledWith(
+      '/api/oauth/callback/google?code=authorization-code&state=oauth-state'
+    );
+  });
+
+  it('does not relay provider codes while rendering on the server', async () => {
+    const location = {
+      search: '?code=authorization-code',
+      replace: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [OAuthCallbackComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'server' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParams: of({ code: 'authorization-code' }),
+            snapshot: { paramMap: { get: () => 'google' } },
+          },
+        },
+        { provide: Router, useValue: { navigateByUrl: jest.fn() } },
+        { provide: DOCUMENT, useValue: { location } },
+      ],
+    }).compileComponents();
+
+    TestBed.runInInjectionContext(() => {
+      new OAuthCallbackComponent(TestBed.inject(ActivatedRoute)).ngOnInit();
+    });
+
+    expect(location.replace).not.toHaveBeenCalled();
+  });
+});

--- a/libs/auth-ui/src/lib/oauth-callback/oauth-callback.component.ts
+++ b/libs/auth-ui/src/lib/oauth-callback/oauth-callback.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, PLATFORM_ID, inject } from '@angular/core';
-import { isPlatformBrowser, CommonModule } from '@angular/common';
-import { ActivatedRoute, Router } from '@angular/router';
+import { DOCUMENT, isPlatformBrowser, CommonModule } from '@angular/common';
+import { ActivatedRoute, Route, Router } from '@angular/router';
 import { API_BASE_URL } from '@optimistic-tanuki/ui-models';
 
 @Component({
@@ -80,7 +80,9 @@ export class OAuthCallbackComponent implements OnInit {
   error: string | null = null;
   private platformId = inject(PLATFORM_ID);
   private readonly router = inject(Router);
-  private readonly apiBaseUrl = inject(API_BASE_URL);
+  private readonly apiBaseUrl =
+    inject(API_BASE_URL, { optional: true }) ?? '/api';
+  private readonly document = inject(DOCUMENT);
 
   constructor(private route: ActivatedRoute) {}
 
@@ -99,8 +101,8 @@ export class OAuthCallbackComponent implements OnInit {
       const errorDescription = params['error_description'];
 
       if (provider && (code || error)) {
-        const query = new URLSearchParams(window.location.search);
-        window.location.replace(
+        const query = new URLSearchParams(this.document.location.search);
+        this.document.location.replace(
           `${this.apiBaseUrl}/oauth/callback/${encodeURIComponent(
             provider
           )}?${query.toString()}`
@@ -169,3 +171,7 @@ export class OAuthCallbackComponent implements OnInit {
     }
   }
 }
+
+export const oauthCallbackRoutes: readonly Route[] = [
+  { path: 'oauth/callback', component: OAuthCallbackComponent },
+];

--- a/tools/registry/apps.production.sample.yaml
+++ b/tools/registry/apps.production.sample.yaml
@@ -17,9 +17,9 @@ apps:
   - appId: system-configurator
     name: HAI Computer
     domain: hopefulaspirationsindustries.com
-    subdomain: computer
-    uiBaseUrl: https://computer.hopefulaspirationsindustries.com
-    apiBaseUrl: https://hopefulaspirationsindustries.com/api
+    subdomain: hardware
+    uiBaseUrl: https://hardware.hopefulaspirationsindustries.com
+    apiBaseUrl: https://hardware.hopefulaspirationsindustries.com/api
     appType: client
     visibility: public
     authEmail:
@@ -67,7 +67,7 @@ apps:
     domain: hopefulaspirationsindustries.com
     subdomain: store
     uiBaseUrl: https://store.hopefulaspirationsindustries.com
-    apiBaseUrl: https://hopefulaspirationsindustries.com/api
+    apiBaseUrl: https://store.hopefulaspirationsindustries.com/api
     appType: client
     visibility: public
     description: Public storefront for HAI products, services, and bookings.
@@ -77,7 +77,7 @@ apps:
     name: Towne Square
     domain: towne-square.com
     uiBaseUrl: https://towne-square.com
-    apiBaseUrl: https://api.hopefulaspirationsindustries.com
+    apiBaseUrl: https://towne-square.com/api
     appType: client
     visibility: public
     authEmail: { enabled: true, from: no-reply@towne-square.com }
@@ -156,3 +156,11 @@ apps:
     authEmail: { enabled: true, from: no-reply@christopherrutherford.net }
     description: Self-configurable business site.
     sortOrder: 54
+  - appId: video-platform
+    name: Video Platform
+    domain: experiments.christopherrutherford.net
+    subdomain: video
+    uiBaseUrl: https://video.experiments.christopherrutherford.net
+    apiBaseUrl: https://video.experiments.christopherrutherford.net/api
+    appType: client
+    visibility: public


### PR DESCRIPTION
This pull request introduces a shared OAuth callback route across multiple applications to centralize and standardize OAuth popup handling. The `oauthCallbackRoutes` from `@optimistic-tanuki/auth-ui` is now registered as the first route in each app's route configuration, ensuring consistent authentication behavior. Comprehensive tests are added to verify that the callback route is properly registered and prioritized before key application routes.

**OAuth Callback Integration**

* Added `oauthCallbackRoutes` to the top of the route arrays in all main app route files (`app.routes.ts`), ensuring the shared OAuth popup callback is registered as the first route. [[1]](diffhunk://#diff-5a77c878869ce9ddea2abf6e1ace1089a7bbeeb15c3f75ad3a1c9553b42d3dfeR2-R5) [[2]](diffhunk://#diff-23650bd8188af993d7da72b1a4a44e90214e878bd0333babc1ddce6308afb2d2L13-R16) [[3]](diffhunk://#diff-23650bd8188af993d7da72b1a4a44e90214e878bd0333babc1ddce6308afb2d2R124) [[4]](diffhunk://#diff-e26c9d6b51598293da75ebb1cfdeeac645ffbb9ec49ecc6cc75d417f7168c0a8R2-R5) [[5]](diffhunk://#diff-9c9ab5511e71cac7a06425e160b51f571495c7b65f69938e1cc941fd646f1bb7R2-R7) [[6]](diffhunk://#diff-c539865ace5e459cfab835ec157ce660b4d6786ca9592d68d9d3ac56df8ad4b9R2-R4) [[7]](diffhunk://#diff-7d1302333b08332c968154f0135157a954b49c36fa20461896e8c1967de90e32R2-R5) [[8]](diffhunk://#diff-a986db06459395d6a3610f7c1563c04da3f524c5559361529fc90af661b65f71R2-R5) [[9]](diffhunk://#diff-3c3111481e468054b7977da0f0d0e0fa183d8df292372250078f8e2062d7d4c6R2-R6) [[10]](diffhunk://#diff-1362554f31fa08b8ed27e9f245778db6d54ee2f86da9d1a195d7425a514e60b5R2-R9) [[11]](diffhunk://#diff-258aeb7813df1bcbc342a34d81895de0756279120c6b13d55491b8583f4d1842R2) [[12]](diffhunk://#diff-258aeb7813df1bcbc342a34d81895de0756279120c6b13d55491b8583f4d1842R26)

**Testing and Verification**

* Added or updated spec files for each app to verify that the `oauth/callback` route is present and appears before important fallback or root routes, ensuring correct routing order. [[1]](diffhunk://#diff-932743aa7d1171546e244e00684c2de4c01d013e79478b534ef833aed9103515R1-R16) [[2]](diffhunk://#diff-125c2af3cc92f4650c2d660eedea6e37f63f1cecff0e78dd963aa80f26b72dfdR1) [[3]](diffhunk://#diff-125c2af3cc92f4650c2d660eedea6e37f63f1cecff0e78dd963aa80f26b72dfdR11-R22) [[4]](diffhunk://#diff-08d735a3967d8cf37fd84c6e9c303fd136751adebfaad49740ca19b447177e31R1-R16) [[5]](diffhunk://#diff-d125cb7242b684dc2a64fb59c9504e36502295465a7c940824babdaf73fdf050R1-R16) [[6]](diffhunk://#diff-fcf129f4306fafecf1ce7ebb89e428e5dcf00ed8e942d3d2b22fdc3b51ece9b2R1-R13) [[7]](diffhunk://#diff-99ec8a25cb2cd03ceb0b81e050326634372fd0af1bf90f062de3e0db75c29d8fR1-R16) [[8]](diffhunk://#diff-4f3a7e83fcc3a074e4165f5e1092c9fe4c2e2fffda31911696a9fec2696538c3R1-R16) [[9]](diffhunk://#diff-787a7a5ce8b0f7d411c916ff9191e61f2d5d64b50413d4966060012fa9aa6f5eR1-R16) [[10]](diffhunk://#diff-f28c451739bc57d69dc63d4f37f8dfb1a9fbc5ac833b403ff72173f1e30c1522R1-R16) [[11]](diffhunk://#diff-ff51692f8036265f519a28c9bad4270b0b70bec9bcb48282a51994353e7872a2R2-R27)

These changes ensure a unified and reliable OAuth authentication flow across all applications in the monorepo.