### PR TITLE
fix classifieds, wellness, and admin-api docker crashes

### DIFF
--- a/apps/admin-api/Dockerfile
+++ b/apps/admin-api/Dockerfile
@@ -20,6 +20,7 @@ RUN pnpm exec nx build admin-api
 FROM node:22-alpine
 RUN apk add --no-cache docker-cli docker-cli-compose
 WORKDIR /app
+ENV NODE_ENV=production
 COPY --from=builder /app/dist/apps/admin-api/package.json ./package.json
 COPY --from=builder /app/dist/apps/admin-api/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN corepack enable && corepack prepare pnpm@11.0.9 --activate && CI=true pnpm install --prod --frozen-lockfile --ignore-scripts

--- a/apps/admin-api/src/app/auth/admin-api-auth.module.spec.ts
+++ b/apps/admin-api/src/app/auth/admin-api-auth.module.spec.ts
@@ -1,0 +1,12 @@
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../app.module';
+
+describe('AppModule', () => {
+  it('resolves all authorization dependencies', async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    expect(module).toBeDefined();
+  });
+});

--- a/apps/admin-api/src/app/auth/admin-api-auth.module.ts
+++ b/apps/admin-api/src/app/auth/admin-api-auth.module.ts
@@ -1,9 +1,19 @@
 import { Module } from '@nestjs/common';
 import { OwnerAuthorizationGuard } from './owner-authorization.guard';
-import { OwnerAuthorizationService } from './owner-authorization.service';
+import {
+  OwnerAuthorizationService,
+  OWNER_AUTHORIZATION_FETCH,
+} from './owner-authorization.service';
 
 @Module({
-  providers: [OwnerAuthorizationService, OwnerAuthorizationGuard],
-  exports: [OwnerAuthorizationGuard],
+  providers: [
+    {
+      provide: OWNER_AUTHORIZATION_FETCH,
+      useValue: fetch,
+    },
+    OwnerAuthorizationService,
+    OwnerAuthorizationGuard,
+  ],
+  exports: [OwnerAuthorizationService, OwnerAuthorizationGuard],
 })
 export class AdminApiAuthModule {}

--- a/apps/admin-api/src/app/auth/owner-authorization.service.ts
+++ b/apps/admin-api/src/app/auth/owner-authorization.service.ts
@@ -1,5 +1,6 @@
 import {
   ForbiddenException,
+  Inject,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -8,6 +9,8 @@ import { JwtService } from '@nestjs/jwt';
 
 type OwnerTokenPayload = { profileId?: string };
 type FetchLike = typeof fetch;
+
+export const OWNER_AUTHORIZATION_FETCH = Symbol('OWNER_AUTHORIZATION_FETCH');
 
 const OWNER_ROLE_NAMES = new Set([
   'owner_console_owner',
@@ -20,6 +23,7 @@ const OWNER_ROLE_NAMES = new Set([
 export class OwnerAuthorizationService {
   constructor(
     private readonly config: ConfigService,
+    @Inject(OWNER_AUTHORIZATION_FETCH)
     private readonly fetchImpl: FetchLike = fetch
   ) {}
 

--- a/apps/classifieds/Dockerfile
+++ b/apps/classifieds/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig*.json nx.json ./
 COPY libs/ ./libs/
 COPY apps/classifieds/ ./apps/classifieds/
 RUN corepack enable && corepack prepare pnpm@11.0.9 --activate && pnpm install --frozen-lockfile
-RUN pnpm exec nx build classifieds --configuration=development
+RUN pnpm exec nx build classifieds --configuration=production
 
 FROM base AS runner
 WORKDIR /app

--- a/apps/wellness/Dockerfile
+++ b/apps/wellness/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig*.json nx.json ./
 COPY libs/ ./libs/
 COPY apps/wellness/ ./apps/wellness/
 RUN corepack enable && corepack prepare pnpm@11.0.9 --activate && pnpm install --frozen-lockfile
-RUN pnpm exec nx build wellness --configuration=development
+RUN pnpm exec nx build wellness --configuration=production
 
 FROM base AS runner
 WORKDIR /app


### PR DESCRIPTION
This pull request introduces several improvements to the `admin-api` authentication module and updates Docker build configurations for production readiness. The main changes include refactoring dependency injection for better testability, adding a basic module-level test, and ensuring Docker images are built with production settings.

### Authentication module improvements

* Refactored `OwnerAuthorizationService` to inject a fetch implementation via a new `OWNER_AUTHORIZATION_FETCH` token, improving testability and flexibility. The default remains the global `fetch` function. (`admin-api-auth.module.ts`, `owner-authorization.service.ts`) [[1]](diffhunk://#diff-b86ff6bdbb087bf4d618093b8b48ce7a46cf73a9f77cd7c18d661ac37abf17f3L3-R17) [[2]](diffhunk://#diff-2b4e0c7e0925ad5c55f4a23aa023f35a2f8c7827f504a4a57371644ce195713eR3) [[3]](diffhunk://#diff-2b4e0c7e0925ad5c55f4a23aa023f35a2f8c7827f504a4a57371644ce195713eR13-R14) [[4]](diffhunk://#diff-2b4e0c7e0925ad5c55f4a23aa023f35a2f8c7827f504a4a57371644ce195713eR26)
* Updated `AdminApiAuthModule` to provide the `OWNER_AUTHORIZATION_FETCH` token and export `OwnerAuthorizationService` for use in other modules. (`admin-api-auth.module.ts`)

### Testing

* Added a basic test to ensure that all authorization dependencies in `AppModule` resolve correctly. (`admin-api-auth.module.spec.ts`)

### Docker build and environment configuration

* Set `NODE_ENV=production` in the `admin-api` Dockerfile to ensure the app runs in production mode. (`admin-api/Dockerfile`)
* Updated `classifieds` and `wellness` Dockerfiles to build with `--configuration=production` instead of development, ensuring optimized production builds. (`classifieds/Dockerfile`, `wellness/Dockerfile`) [[1]](diffhunk://#diff-51069109df3c1f47b37f0e118994b93eeda4ef29f48ab02609a0299a74e0ca70L10-R10) [[2]](diffhunk://#diff-ab937311c4d29de3ab6028e6ed2a3f4367aae8604e53bed6adb16fcdd15b4983L10-R10)