### PR TITLE
• Fixed the bootstrap owner permission flow.

### DIFF
--- a/apps/admin-api/src/app/bootstrap/bootstrap.service.spec.ts
+++ b/apps/admin-api/src/app/bootstrap/bootstrap.service.spec.ts
@@ -118,7 +118,7 @@ describe('BootstrapService', () => {
     );
   });
 
-  it('returns an existing legacy global owner without creating another account', async () => {
+  it('repairs global and owner-console permissions for an existing global owner', async () => {
     const authClient = {
       send: jest.fn(),
     };
@@ -156,5 +156,24 @@ describe('BootstrapService', () => {
     });
 
     expect(authClient.send).not.toHaveBeenCalled();
+    expect(roleInit.processNow).toHaveBeenCalledTimes(2);
+    expect(roleInit.processNow).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        scopeName: 'global',
+        assignments: expect.arrayContaining([
+          expect.objectContaining({ roleName: 'owner' }),
+        ]),
+      })
+    );
+    expect(roleInit.processNow).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        scopeName: 'owner-console',
+        assignments: expect.arrayContaining([
+          expect.objectContaining({ roleName: 'owner_console_owner' }),
+        ]),
+      })
+    );
   });
 });

--- a/apps/admin-api/src/app/bootstrap/bootstrap.service.spec.ts
+++ b/apps/admin-api/src/app/bootstrap/bootstrap.service.spec.ts
@@ -108,11 +108,22 @@ describe('BootstrapService', () => {
         userId: 'owner-user-1',
       })
     );
-    expect(roleInit.processNow).toHaveBeenCalledWith(
+    expect(roleInit.processNow).toHaveBeenCalledTimes(2);
+    expect(roleInit.processNow).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         scopeName: 'global',
         assignments: expect.arrayContaining([
           expect.objectContaining({ roleName: 'owner' }),
+        ]),
+      })
+    );
+    expect(roleInit.processNow).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        scopeName: 'owner-console',
+        assignments: expect.arrayContaining([
+          expect.objectContaining({ roleName: 'owner_console_owner' }),
         ]),
       })
     );

--- a/apps/admin-api/src/app/bootstrap/bootstrap.service.ts
+++ b/apps/admin-api/src/app/bootstrap/bootstrap.service.ts
@@ -589,6 +589,7 @@ export class BootstrapService {
 
     if (existingGlobalProfiles.length > 0) {
       const existingOwner = existingGlobalProfiles[0];
+      await this.initializeOwnerPermissions(existingOwner.id);
       return {
         created: false,
         email: normalizedEmail,
@@ -639,15 +640,7 @@ export class BootstrapService {
       throw new Error('Owner registration did not return a profile id');
     }
 
-    await this.roleInit.processNow(
-      new RoleInitBuilder()
-        .setScopeName('global')
-        .setProfile(createdProfile.id)
-        .assignOwnerRole()
-        .addOwnerScopeDefaults()
-        .addAssetOwnerPermissions()
-        .build()
-    );
+    await this.initializeOwnerPermissions(createdProfile.id);
 
     const ownerApp = this.loadDeploymentConfig().apps.find(
       (app) => app.appId === 'owner-console'
@@ -684,6 +677,25 @@ export class BootstrapService {
       email: normalizedEmail,
       name,
     };
+  }
+
+  private async initializeOwnerPermissions(profileId: string): Promise<void> {
+    await this.roleInit.processNow(
+      new RoleInitBuilder()
+        .setScopeName('global')
+        .setProfile(profileId)
+        .addOwnerScopeDefaults()
+        .addAssetOwnerPermissions()
+        .build()
+    );
+
+    await this.roleInit.processNow(
+      new RoleInitBuilder()
+        .setScopeName('owner-console')
+        .setProfile(profileId)
+        .addOwnerScopeDefaults()
+        .build()
+    );
   }
 
   async configureOAuthProvider(


### PR DESCRIPTION
  - Existing global owners now have permissions repaired when bootstrap is rerun.
  - Both new and existing owners receive:
      - global owner permissions (owner, related global defaults)
      - owner-console permissions (owner_console_owner)

  - Removed the duplicate global-owner assignment in the prior builder chain.
  - Added a regression test for the existing-owner repair path.

This pull request improves the initialization and repair of owner permissions in the `BootstrapService`. The main enhancement is the introduction of a dedicated method to ensure that both global and owner-console permissions are correctly set up for owner profiles, whether they are newly created or already exist. The associated tests have also been updated to verify this behavior.

**Owner Permission Initialization and Repair:**

* Added a new private method `initializeOwnerPermissions` to `BootstrapService` that ensures both global and owner-console permissions are properly assigned to an owner profile. This method is now called for both new and existing owner profiles. [[1]](diffhunk://#diff-4f177b14f82107a3af553fb83ac1942fd2541111a8ccb414bbd12da79bec70e0R682-R700) [[2]](diffhunk://#diff-4f177b14f82107a3af553fb83ac1942fd2541111a8ccb414bbd12da79bec70e0L642-R643) [[3]](diffhunk://#diff-4f177b14f82107a3af553fb83ac1942fd2541111a8ccb414bbd12da79bec70e0R592)

**Test Enhancements:**

* Updated the test case to verify that `initializeOwnerPermissions` correctly repairs both global and owner-console permissions for an existing global owner, checking that the appropriate role assignments are made. [[1]](diffhunk://#diff-54d4e1f5f65b516596dbbdb69a7c0d1fcb01223f6b77f489f4ea251e63c941fcL121-R121) [[2]](diffhunk://#diff-54d4e1f5f65b516596dbbdb69a7c0d1fcb01223f6b77f489f4ea251e63c941fcR159-R177)